### PR TITLE
キーマップの修正とtap設定変更

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -12,6 +12,7 @@
 
 &trackball {
     // automouse-layer = <4>;
+
     scroll-layers = <5>;
 
     // arrows {
@@ -43,7 +44,7 @@
 
         pipe {
             bindings = <&kp PIPE>;
-            key-positions = <5 17>;
+            key-positions = <6 18>;
         };
 
         double_quote {

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -166,13 +166,13 @@
 
         leyer_3 {
             bindings = <
-&kp F11  &kp F12  &kp F13  &kp F14  &kp F15                      &kp F16                   &kp F17        &kp F18        &trans   &trans
-&kp F6   &kp F7   &kp F8   &kp F9   &kp F10  &trans      &trans  &kp LA(LG(H))             &kp HOME       &kp PAGE_UP    &kp END  &trans
-&kp F1   &kp F2   &kp F3   &kp F4   &kp F5   &trans      &trans  &kp LC(LS(LG(NUMBER_4)))  &kp LA(LG(L))  &kp PAGE_DOWN  &trans   &trans
-&trans   &trans   &trans   &trans   &trans   &trans      &trans  &trans                                                           &trans
+&kp F11  &kp F12  &kp F13  &kp F14  &kp F15                      &kp F16  &kp F17   &kp F18        &trans   &trans
+&kp F6   &kp F7   &kp F8   &kp F9   &kp F10  &trans      &trans  &trans   &kp HOME  &kp PAGE_UP    &kp END  &trans
+&kp F1   &kp F2   &kp F3   &kp F4   &kp F5   &trans      &trans  &trans   &trans    &kp PAGE_DOWN  &trans   &trans
+&trans   &trans   &trans   &trans   &trans   &trans      &trans  &trans                                     &trans
             >;
 
-            sensor-bindings = <&inc_dec_kp LC(PAGE_UP) LC(PAGE_DOWN)>;
+            sensor-bindings = <&inc_dec_kp LC(C_VOL_UP) LC(C_VOL_DN)>;
         };
 
         layer_4 {
@@ -186,10 +186,10 @@
 
         layer_5 {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                      &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                          &trans
+&trans  &trans  &trans  &trans  &trans                      &trans                    &trans         &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &kp LA(LG(H))             &trans         &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &kp LS(LC(LG(NUMBER_4)))  &kp LA(LG(L))  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                                                   &trans
             >;
         };
 

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -172,7 +172,7 @@
 &trans   &trans   &trans   &trans   &trans   &trans      &trans  &trans                                     &trans
             >;
 
-            sensor-bindings = <&inc_dec_kp LC(C_VOL_UP) LC(C_VOL_DN)>;
+            sensor-bindings = <&inc_dec_kp LC(C_VOL_DN) LC(C_VOL_UP)>;
         };
 
         layer_4 {

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -7,7 +7,8 @@
 
 &mt {
     flavor = "balanced";
-    quick-tap-ms = <0>;
+    quick-tap-ms = <150>;
+    tapping-term-ms = <150>;
 };
 
 &trackball {


### PR DESCRIPTION
- キーマップ
  - 元々layer3に設定していたいくつかのキーをlayer5に移動
  - layer3のエンコーダで音量の上下を可能に
- tap設定
  - tapping-term-msの追加
    - 元のkeyballにしていた設定と同様
  - quick-tap-msを150msに