### PR TITLE
不要なfunctionキーをキーマップから削除

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -169,10 +169,10 @@
 
         layer_3 {
             bindings = <
-&kp F11  &kp F12  &kp F13  &kp F14  &kp F15                      &kp F16  &kp F17   &kp F18        &trans   &trans
-&kp F6   &kp F7   &kp F8   &kp F9   &kp F10  &trans      &trans  &trans   &kp HOME  &kp PAGE_UP    &kp END  &trans
-&kp F1   &kp F2   &kp F3   &kp F4   &kp F5   &trans      &trans  &trans   &trans    &kp PAGE_DOWN  &trans   &trans
-&trans   &trans   &trans   &trans   &trans   &trans      &trans  &trans                                     &trans
+&kp F1   &kp F2   &kp F3  &kp F4  &kp F5                       &trans  &trans    &trans         &trans   &trans
+&kp F6   &kp F7   &kp F8  &kp F9  &kp F10  &trans      &trans  &trans  &kp HOME  &kp PAGE_UP    &kp END  &trans
+&kp F11  &kp F12  &trans  &trans  &trans   &trans      &trans  &trans  &trans    &kp PAGE_DOWN  &trans   &trans
+&trans   &trans   &trans  &trans  &trans   &trans      &trans  &trans                                    &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LC(C_VOL_DN) LC(C_VOL_UP)>;


### PR DESCRIPTION
- layer3のfunctionキーをf1〜f12までに変更
- 上から順番にf1~f12になるように位置を変更