### PR TITLE
キーマップの最適化

### DIFF
--- a/.github/workflows/draw.yml
+++ b/.github/workflows/draw.yml
@@ -2,12 +2,13 @@ name: "Draw Keymap"
 
 on:
   workflow_dispatch:
-  # push時に自動で実行する場合は、以下のコメントアウトを外す
-  # push:
-  #   paths:
-  #     - "config/roBa.keymap"
-  #     - "keymap_drawer.config.yaml"
-  #     - "config/roBa.dtsi"
+  push:
+    branches:
+      - main
+    paths:
+      - "config/roBa.keymap"
+      - "keymap_drawer.config.yaml"
+      - "config/roBa.dtsi"
 
 jobs:
   draw:

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -115,12 +115,12 @@
 
         lpar {
             bindings = <&kp LEFT_PARENTHESIS>;
-            key-positions = <4 3>;
+            key-positions = <3 2>;
         };
 
         rpar {
             bindings = <&kp RIGHT_PARENTHESIS>;
-            key-positions = <13 14>;
+            key-positions = <3 4>;
         };
 
         at {
@@ -141,6 +141,26 @@
         caret {
             bindings = <&kp CARET>;
             key-positions = <27 26>;
+        };
+
+        lbkt {
+            bindings = <&kp LEFT_BRACKET>;
+            key-positions = <5 6>;
+        };
+
+        rbkt {
+            bindings = <&kp RIGHT_BRACKET>;
+            key-positions = <6 7>;
+        };
+
+        lbrc {
+            bindings = <&kp LEFT_BRACE>;
+            key-positions = <17 18>;
+        };
+
+        rbrc {
+            bindings = <&kp RBRC>;
+            key-positions = <18 19>;
         };
     };
 

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -209,10 +209,10 @@
 
         layer_1 {
             bindings = <
-&trans  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &trans                                &kp LEFT_BRACKET   &kp RIGHT_BRACKET  &kp BACKSLASH   &kp PLUS         &kp GRAVE
-&trans  &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &trans  &kp LG(NUMBER_0)      &trans  &kp SQT            &kp LEFT_ARROW     &kp UP_ARROW    &kp RIGHT_ARROW  &kp SEMICOLON
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &trans  &trans                &trans  &kp DOUBLE_QUOTES  &trans             &kp DOWN_ARROW  &trans           &trans
-&trans  &trans        &kp N0        &trans        &trans  &trans                &trans  &trans                                                                 &trans
+&trans  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &trans                                &trans  &trans          &trans          &trans           &trans
+&trans  &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &trans  &kp LG(NUMBER_0)      &trans  &trans  &kp LEFT_ARROW  &kp UP_ARROW    &kp RIGHT_ARROW  &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &trans  &trans                &trans  &trans  &trans          &kp DOWN_ARROW  &trans           &trans
+&trans  &trans        &kp N0        &trans        &trans  &trans                &trans  &trans                                                   &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LG(MINUS) LG(PLUS)>;

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -198,10 +198,10 @@
 
         default_layer {
             bindings = <
-&kp Q                       &kp W             &kp E                 &kp R                   &kp T                                          &kp Y        &kp U  &kp I        &kp O     &kp P
-&mt RCTRL A                 &kp S             &kp D                 &kp F                   &kp G        &mkp MB3           &kp DELETE     &kp H        &kp J  &mt LCTRL K  &lt 5 L   &lt 3 MINUS
-&kp Z                       &kp X             &kp C                 &kp V                   &kp B        &kp BACKSLASH      &lt 4 PLUS     &kp N        &kp M  &mkp MB1     &mkp MB2  &lt 1 SLASH
-&mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LEFT_SHIFT LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &lt 2 TAB          &kp BACKSPACE  &lt 2 ENTER                                &mt LS(LEFT_COMMAND) PERIOD
+&kp Q                       &kp W             &kp E            &kp R                   &kp T                                               &kp Y        &kp U  &kp I     &kp O     &kp P
+&kp A                       &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt 5 L   &lt 3 MINUS
+&kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp BACKSLASH           &lt 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt 1 SLASH
+&mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
             >;
 
             sensor-bindings = <&encoder_msc_down_up>;
@@ -220,10 +220,10 @@
 
         layer_2 {
             bindings = <
-&trans  &kp AMPERSAND    &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                      &kp LEFT_BRACE  &kp RIGHT_BRACE       &kp PIPE            &kp EQUAL              &kp TILDE
-&trans  &kp DOLLAR       &kp PERCENT   &kp CARET             &trans                 &trans      &trans  &trans          &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &kp COLON
-&trans  &kp EXCLAMATION  &kp AT_SIGN   &kp HASH              &trans                 &trans      &trans  &trans          &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &kp QUESTION
-&trans  &trans           &trans        &trans                &trans                 &trans      &trans  &trans                                                                           &trans
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans                &trans              &trans                 &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                                                                   &trans
             >;
         };
 

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -58,6 +58,26 @@
             key-positions = <7 19>;
         };
 
+        lbkt {
+            bindings = <&kp LEFT_BRACKET>;
+            key-positions = <5 6>;
+        };
+
+        rbkt {
+            bindings = <&kp RIGHT_BRACKET>;
+            key-positions = <6 7>;
+        };
+
+        lbrc {
+            bindings = <&kp LEFT_BRACE>;
+            key-positions = <17 18>;
+        };
+
+        rbrc {
+            bindings = <&kp RBRC>;
+            key-positions = <18 19>;
+        };
+
         tilde {
             bindings = <&kp TILDE>;
             key-positions = <4 14>;
@@ -128,6 +148,11 @@
             key-positions = <26 25>;
         };
 
+        caret {
+            bindings = <&kp CARET>;
+            key-positions = <27 26>;
+        };
+
         amps {
             bindings = <&kp AMPERSAND>;
             key-positions = <0 10>;
@@ -136,31 +161,6 @@
         asterisk {
             bindings = <&kp ASTERISK>;
             key-positions = <10 22>;
-        };
-
-        caret {
-            bindings = <&kp CARET>;
-            key-positions = <27 26>;
-        };
-
-        lbkt {
-            bindings = <&kp LEFT_BRACKET>;
-            key-positions = <5 6>;
-        };
-
-        rbkt {
-            bindings = <&kp RIGHT_BRACKET>;
-            key-positions = <6 7>;
-        };
-
-        lbrc {
-            bindings = <&kp LEFT_BRACE>;
-            key-positions = <17 18>;
-        };
-
-        rbrc {
-            bindings = <&kp RBRC>;
-            key-positions = <18 19>;
         };
     };
 


### PR DESCRIPTION
- キーマップ変更
  - 記号を全てコンボキーに設定
  - layer1,2に記号が不要になったためtransに変更
  - 左のlayer2への切り替えボタンをshiftに変更
  - 左のshiftをctrlに変更
  - aとkに設定していたctrlを削除
- キーマップを変更してmainにpushされた際にキーマップ画像も変わるように設定