### PR TITLE
キーマップ調整

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -220,22 +220,22 @@
 
         layer_2 {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                      &trans  &trans                &trans              &trans                 &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                                                                   &trans
+&kp F1   &kp F2   &kp F3  &kp F4  &kp F5                       &trans         &trans                &trans              &trans                 &trans
+&kp F6   &kp F7   &kp F8  &kp F9  &kp F10  &trans      &trans  &kp LA(LG(H))  &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &trans
+&kp F11  &kp F12  &trans  &trans  &trans   &trans      &trans  &kp LA(LG(L))  &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &trans
+&trans   &trans   &trans  &trans  &trans   &trans      &trans  &trans                                                                          &trans
             >;
+
+            sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         layer_3 {
             bindings = <
-&kp F1   &kp F2   &kp F3  &kp F4  &kp F5                       &trans  &trans    &trans         &trans   &trans
-&kp F6   &kp F7   &kp F8  &kp F9  &kp F10  &trans      &trans  &trans  &kp HOME  &kp PAGE_UP    &kp END  &trans
-&kp F11  &kp F12  &trans  &trans  &trans   &trans      &trans  &trans  &trans    &kp PAGE_DOWN  &trans   &trans
-&trans   &trans   &trans  &trans  &trans   &trans      &trans  &trans                                    &trans
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans                    &trans         &trans   &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp HOME                  &kp PAGE_UP    &kp END  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &kp LS(LC(LG(NUMBER_4)))  &kp PAGE_DOWN  &trans   &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                                                    &trans
             >;
-
-            sensor-bindings = <&inc_dec_kp LC(C_VOL_DN) LC(C_VOL_UP)>;
         };
 
         layer_4 {
@@ -249,10 +249,10 @@
 
         layer_5 {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                      &trans                    &trans         &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &kp LA(LG(H))             &trans         &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &kp LS(LC(LG(NUMBER_4)))  &kp LA(LG(L))  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                                                   &trans
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                          &trans
             >;
         };
 


### PR DESCRIPTION
- functionキーをlayer2へ
- layer5にあった通知タブやlaunchpadを開くショートかっとをlayer2へ
- layer5にあったスクリーンショットを撮るショートかっとをlayer3へ
- layer3にあった音量調整のエンコーダ設定をlayer2へ