### PR TITLE
shift+tabの追加

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -220,10 +220,10 @@
 
         layer_2 {
             bindings = <
-&kp F1   &kp F2   &kp F3  &kp F4  &kp F5                       &kp HOME       &kp END               &kp PAGE_UP         &kp PAGE_DOWN          &trans
-&kp F6   &kp F7   &kp F8  &kp F9  &kp F10  &trans      &trans  &kp LA(LG(H))  &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &trans
-&kp F11  &kp F12  &trans  &trans  &trans   &trans      &trans  &kp LA(LG(L))  &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &trans
-&trans   &trans   &trans  &trans  &trans   &trans      &trans  &trans                                                                          &trans
+&kp F1   &kp F2   &kp F3  &kp F4  &kp F5                            &kp HOME       &kp END               &kp PAGE_UP         &kp PAGE_DOWN          &trans
+&kp F6   &kp F7   &kp F8  &kp F9  &kp F10  &trans           &trans  &kp LA(LG(H))  &kp LC(LEFT_ARROW)    &kp LC(UP_ARROW)    &kp LC(RIGHT_ARROW)    &trans
+&kp F11  &kp F12  &trans  &trans  &trans   &trans           &trans  &kp LA(LG(L))  &kp LG(LEFT_BRACKET)  &kp LC(DOWN_ARROW)  &kp LG(RIGHT_BRACKET)  &trans
+&trans   &trans   &trans  &trans  &trans   &kp LS(TAB)      &trans  &trans                                                                          &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;


### PR DESCRIPTION
- キーマップ変更によってshift+tabが打てなくなったことに気づいたので押しやすいlayer2に追加