### PR TITLE
ダークモード時のrect.held.alternateの色が微妙なので変更

### DIFF
--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -6,4 +6,3 @@ draw_config:
   combo_diagrams_scale: 4
   svg_extra_style: |
     rect.held.alternate { fill: #bee9e9; }
-    @media (prefers-color-scheme: dark) { rect.held.alternate { fill: #6ecfcf; } }


### PR DESCRIPTION
- ダークモードで分岐せずに同じ色にする