### PR TITLE
Aにctrlのholdを追加

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -203,7 +203,7 @@
         default_layer {
             bindings = <
 &kp Q                       &kp W             &kp E            &kp R                   &kp T                                               &kp Y        &kp U  &kp I     &kp O     &kp P
-&kp A                       &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt 5 L   &lt 3 MINUS
+&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt 5 L   &lt 3 MINUS
 &kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt 1 SLASH
 &mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
             >;


### PR DESCRIPTION
- やっぱりAにctrlないとterminalで不便なので元に戻す
  - gatherでwasdで動くことそうそうなくなったのでkarabinerで例外作る必要がなくなり、普通にleft ctrlに変更