### PR TITLE
キーマップ変更

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -11,6 +11,11 @@
     tapping-term-ms = <150>;
 };
 
+&lt {
+    flavor = "balanced";
+    quick-tap-ms = <150>;
+};
+
 &trackball {
     // automouse-layer = <4>;
 

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -160,6 +160,7 @@
         amps {
             bindings = <&kp AMPERSAND>;
             key-positions = <0 10>;
+            timeout-ms = <20>;
         };
 
         asterisk {


### PR DESCRIPTION
- &のコンボのtimeoutを短くしてqaが打ちやすいように
- ltのflavorをmtと同じbalancedにし、quick-tap-msを設定