### PR TITLE
ltをhold-preferredに変更

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -12,7 +12,7 @@
 };
 
 &lt {
-    flavor = "balanced";
+    flavor = "hold-preferred";
     quick-tap-ms = <150>;
 };
 


### PR DESCRIPTION
- タイトル通り
  - 高速でタイピングすると数字打つのに失敗することが多いのでそれが解消されることを期待