### PR TITLE
右手親指キーに設置しているltのみhold-preferredになるように設定

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -14,6 +14,7 @@
 &lt {
     flavor = "hold-preferred";
     quick-tap-ms = <150>;
+    tapping-term-ms = <150>;
 };
 
 &trackball {
@@ -184,6 +185,16 @@
     };
 
     behaviors {
+        lt_balanced: lt_balanced {
+            compatible = "zmk,behavior-hold-tap";
+            label = "LT_BALANCED";
+            flavor = "balanced";
+            quick-tap-ms = <150>;
+            tapping-term-ms = <150>;
+            bindings = <&mo>, <&kp>;
+            #binding-cells = <2>;
+        };
+
         lt_to_layer_0: lt_to_layer_0 {
             compatible = "zmk,behavior-hold-tap";
             label = "LAYER_TAP_TO_0";
@@ -209,7 +220,7 @@
         default_layer {
             bindings = <
 &kp Q                       &kp W             &kp E            &kp R                   &kp T                                               &kp Y        &kp U  &kp I     &kp O     &kp P
-&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt 5 L   &lt 3 MINUS
+&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt_balanced 5 L   &lt 3 MINUS
 &kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt 1 SLASH
 &mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
             >;

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -220,8 +220,8 @@
         default_layer {
             bindings = <
 &kp Q                       &kp W             &kp E            &kp R                   &kp T                                               &kp Y        &kp U  &kp I     &kp O     &kp P
-&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt_balanced 5 L   &lt 3 MINUS
-&kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt 1 SLASH
+&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt_balanced 5 L   &lt_balanced 3 MINUS
+&kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt_balanced 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt_balanced 1 SLASH
 &mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
             >;
 

--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -12,7 +12,7 @@
 };
 
 &lt {
-    flavor = "hold-preferred";
+    flavor = "balanced";
     quick-tap-ms = <150>;
     tapping-term-ms = <150>;
 };
@@ -185,10 +185,10 @@
     };
 
     behaviors {
-        lt_balanced: lt_balanced {
+        lt_hold: lt_hold {
             compatible = "zmk,behavior-hold-tap";
-            label = "LT_BALANCED";
-            flavor = "balanced";
+            label = "LT_HOLD";
+            flavor = "hold-preferred";
             quick-tap-ms = <150>;
             tapping-term-ms = <150>;
             bindings = <&mo>, <&kp>;
@@ -220,9 +220,9 @@
         default_layer {
             bindings = <
 &kp Q                       &kp W             &kp E            &kp R                   &kp T                                               &kp Y        &kp U  &kp I     &kp O     &kp P
-&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt_balanced 5 L   &lt_balanced 3 MINUS
-&kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt_balanced 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt_balanced 1 SLASH
-&mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
+&mt LCTRL A                 &kp S             &kp D            &kp F                   &kp G        &mkp MB3                &kp DELETE     &kp H        &kp J  &kp K     &lt 5 L   &lt 3 MINUS
+&kp Z                       &kp X             &kp C            &kp V                   &kp B        &kp AT_SIGN             &lt 4 PLUS     &kp N        &kp M  &mkp MB1  &mkp MB2  &lt 1 SLASH
+&mt LC(LEFT_COMMAND) COMMA  &mt LEFT_ALT ESC  &mt LCTRL LANG2  &mt LEFT_COMMAND LANG1  &lt_hold 1 SPACE  &mt LEFT_SHIFT TAB      &kp BACKSPACE  &lt 2 ENTER                             &mt LS(LEFT_COMMAND) PERIOD
             >;
 
             sensor-bindings = <&encoder_msc_down_up>;


### PR DESCRIPTION
- ltと別にlt_holdを設定
  - 数字キーを打つときのタイプミス軽減が目的
  - 他のレイヤータップはbalancedの方が良いためそのまま